### PR TITLE
Rework of summary_factorlist() to reduce code duplication

### DIFF
--- a/R/summaryfactorlist.R
+++ b/R/summaryfactorlist.R
@@ -90,7 +90,7 @@ summary_factorlist <- function(.data, dependent = NULL, explanatory, cont = "mea
 		warning("Dependent variable is a survival object")
 		.data$all = factor(1, labels="all")
 		suppressWarnings(
-			do.call(summary_factorlist1, args=list(.data = .data, dependent = "all",  explanatory = explanatory, fit_id = fit_id))
+			do.call(summary_factorlist_groups, args=list(.data = .data, dependent = "all",  explanatory = explanatory, fit_id = fit_id))
 		)
 	} else {
 
@@ -113,19 +113,7 @@ summary_factorlist <- function(.data, dependent = NULL, explanatory, cont = "mea
 			warning("Dependent is not a factor and will be treated as a continuous variable")
 			do.call(summary_factorlist0, args)
 		} else {
-
-			# Factor case
-			if (d.len == 1){
-				do.call(summary_factorlist1, args)
-			} else if (d.len == 2){
-				do.call(summary_factorlist2, args)
-			} else if (d.len == 3){
-				do.call(summary_factorlist3, args)
-			} else if (d.len == 4){
-				do.call(summary_factorlist4, args)
-			} else if (d.len == 5){
-				do.call(summary_factorlist5, args)
-			}
+			do.call(summary_factorlist_groups, args)
 		}
 	}
 }
@@ -193,7 +181,7 @@ summary_factorlist0 <- function(.data, dependent, explanatory,  cont = "mean", c
 	}
 
 	df.out = cbind(df.out, result.out)
-	
+
 	if (total_col){
 		total.out = matrix(s[,1])
 		df.out = cbind(df.out, "Total" = total.out)
@@ -210,67 +198,34 @@ summary_factorlist0 <- function(.data, dependent, explanatory,  cont = "mean", c
 }
 
 
-
 #' Summarise a set of factors by a dependent variable
 #'
 #' Internal function, not called directly.
 #'
 #' @keywords internal
-summary_factorlist1 <- function(.data, dependent, explanatory,  cont = "mean", cont_cut = 5, p = FALSE, na_include = FALSE,
-																column = FALSE, total_col = FALSE, orderbytotal = FALSE, fit_id = FALSE,
-																na_to_missing = TRUE, add_dependent_label = FALSE,
-																dependent_label_prefix = "Dependent: ", dependent_label_suffix = ""){
+summary_factorlist_groups <- function(.data, dependent, explanatory,  cont = "mean", cont_cut = 5, p = FALSE, na_include = FALSE,
+									  column = FALSE, total_col = FALSE, orderbytotal = FALSE, fit_id = FALSE,
+									  na_to_missing = TRUE, add_dependent_label = FALSE,
+									  dependent_label_prefix = "Dependent: ", dependent_label_suffix = ""){
 
 	s <- summary_formula(as.formula(paste(dependent, "~", paste(explanatory, collapse = "+"))), data = .data,
-											 method = "reverse", overall = FALSE,
-											 test = TRUE,na.include = na_include, continuous = cont_cut)
-	df.out = plyr::ldply(s$stats, function(x){
-		if(dim(x)[2] == 13){ #hack to get continuous vs categorical. Wouldn't work for factor with 13 levels
-			# Continuous variables
-			# Mean (SD)
-			if (cont == "mean"){
-				a = paste0(round(x[1,12], 1), " (", round(x[1,13], 1), ")")
-				row1_name = dimnames(x)[[2]][12]
-				row2_name = dimnames(x)[[2]][13]
-			}
+						 method = "reverse", overall = FALSE,
+						 test = TRUE,na.include = na_include, continuous = cont_cut)
+	df.out = plyr::ldply(1:length(s$stats), function(index) {
+		x = s$stats[[index]]
+		is_continuous = s$type[index] == 2
 
-			# Median (IQR)
-			if (cont == "median"){
-				a = paste0(x[1,6], " (", x[1,8]-x[1,4], ")")
-				row1_name = "Median"
-				row2_name = "IQR"}
-
-			col1_name = dimnames(x)[[1]][1]
-			df.out = data.frame(paste0(row1_name, " (", row2_name, ")"), a)
-			names(df.out) = c("levels", col1_name)
-			return(df.out)
-
+		if (is_continuous) {
+			df.out = summarize_continuous(x, cont = cont)
 		} else {
 			# Factor variables
-			row_name = dimnames(x)$w
-			col1_name = dimnames(x)$g[1]
-			col1 = x[,1]
-			total = col1
-			if (column == FALSE) {
-				col1_prop = (col1/apply(x, 1, sum))*100 # row margin
-			} else {
-				col1_prop = (col1/sum(col1))*100 # column margin
-				total_prop = (total/sum(total))*100
-			}
-			a = paste0(col1, " (", sprintf("%.1f", round(col1_prop, 1)), ")") #sprintf to keep trailing zeros
-			if (total_col == FALSE){
-				df.out = data.frame(row_name, a)
-				names(df.out) = c("levels", col1_name)
-			} else if (total_col == TRUE & column == FALSE) {
-				df.out = data.frame(row_name, a, total, total)
-				names(df.out) = c("levels", col1_name, "Total", "index_total")
-			} else if (total_col == TRUE & column == TRUE) {
-				df.out = data.frame(row_name, a, paste0(total, " (", sprintf("%.1f", round(total_prop, 1)), ")"), total)
-				names(df.out) = c("levels", col1_name, "Total", "index_total")
-			}
+			df.out = summarize_categorical(x, column = column, total_col = total_col)
 		}
+		df.out[[".id"]] = names(s$stats)[index]
+
 		return(df.out)
-	})
+	}, .id = NULL)
+
 	# Keep original order
 	df.out$index = 1:dim(df.out)[1]
 
@@ -318,513 +273,108 @@ summary_factorlist1 <- function(.data, dependent, explanatory,  cont = "mean", c
 	# Add dependent name label
 	if(add_dependent_label){
 		df.out.labels = dependent_label(df.out=df.out.labels, .data=.data, dependent,
-																		prefix=dependent_label_prefix, suffix = dependent_label_suffix)
+										prefix=dependent_label_prefix, suffix = dependent_label_suffix)
 	}
 
 	return(df.out.labels)
 }
 
 
-
-
-#' Summarise a set of factors by a dependent variable
+#' Helper function to generate the summary for a continuous variable
 #'
 #' Internal function, not called directly.
 #'
 #' @keywords internal
+summarize_continuous = function(x, cont) {
+	# Workaround for CRAN checks: need to declare any variables that
+	#   will be used in dplyr non-standard evaluation
+	Mean = NULL; SD = NULL; Median = NULL; Q3 = NULL; Q1 = NULL;
+	IQR = NULL; Formatted = NULL;
 
-summary_factorlist2 <- function(.data, dependent, explanatory,  cont = "mean", cont_cut = 5, p = FALSE, na_include = FALSE,
-																column = FALSE, total_col = FALSE, orderbytotal = FALSE, fit_id = FALSE,
-																na_to_missing = TRUE, add_dependent_label = FALSE,
-																dependent_label_prefix = "Dependent: ", dependent_label_suffix = ""){
-
-	s <- summary_formula(as.formula(paste(dependent, "~", paste(explanatory, collapse = "+"))), data = .data,
-											 method = "reverse", overall = FALSE,
-											 test = TRUE, na.include = na_include, continuous = cont_cut)
-	df.out = plyr::ldply(s$stats, function(x){
-		if(dim(x)[2] == 13){ #hack to get continuous vs categorical. Wouldn't work for factor with 13 levels
-			# Continuous variables
-			# Mean (SD)
-			if (cont == "mean"){
-				a = paste0(round(x[1,12], 1), " (", round(x[1,13], 1), ")")
-				b = paste0(round(x[2,12], 1), " (", round(x[2,13], 1), ")")
-				row1_name = dimnames(x)[[2]][12]
-				row2_name = dimnames(x)[[2]][13]
-			}
-
-			# Median (IQR)
-			if (cont == "median"){
-				a = paste0(x[1,6], " (", x[1,8]-x[1,4], ")")
-				b = paste0(x[2,6], " (", x[2,8]-x[2,4], ")")
-				row1_name = "Median"
-				row2_name = "IQR"}
-
-			col1_name = dimnames(x)[[1]][1]
-			col2_name = dimnames(x)[[1]][2]
-			df.out = data.frame(paste0(row1_name, " (", row2_name, ")"), a, b)
-			names(df.out) = c("levels", col1_name, col2_name)
-			return(df.out)
-		} else {
-			# Factor variables
-			row_name = dimnames(x)$w
-			col1_name = dimnames(x)$g[1]
-			col2_name = dimnames(x)$g[2]
-			col1 = x[,1]
-			col2 = x[,2]
-			total = col1 + col2
-			if (column == FALSE) {
-				col1_prop = (col1/apply(x, 1, sum))*100 # row margin
-				col2_prop = (col2/apply(x, 1, sum))*100
-			} else {
-				col1_prop = (col1/sum(col1))*100 # column margin
-				col2_prop = (col2/sum(col2))*100
-				total_prop = (total/sum(total))*100
-			}
-			a = paste0(col1, " (", sprintf("%.1f", round(col1_prop, 1)), ")") #sprintf to keep trailing zeros
-			b = paste0(col2, " (", sprintf("%.1f", round(col2_prop, 1)), ")")
-			if (total_col == FALSE){
-				df.out = data.frame(row_name, a, b)
-				names(df.out) = c("levels", col1_name, col2_name)
-			} else if (total_col == TRUE & column == FALSE) {
-				df.out = data.frame(row_name, a, b, total, total)
-				names(df.out) = c("levels", col1_name, col2_name, "Total", "index_total")
-			} else if (total_col == TRUE & column == TRUE) {
-				df.out = data.frame(row_name, a, b, paste0(total, " (", sprintf("%.1f", round(total_prop, 1)), ")"), total)
-				names(df.out) = c("levels", col1_name, col2_name, "Total", "index_total")
-			}
-		}
-		return(df.out)
-	})
-	# Keep original order
-	df.out$index = 1:dim(df.out)[1]
-
-	if (p == TRUE){
-		a = plyr::ldply(s$testresults, function(x) sprintf("%.3f",round(x[[1]], 3)))
-		names(a) = c(".id", "p")
-		df.out = merge(df.out, a, by=".id")
+	if (cont == "mean") {
+		df_out = x %>%
+			as.data.frame() %>%
+			dplyr::mutate(
+				Label = rownames(.),
+				Formatted = paste0(round(Mean, 1), " (",
+								   round(SD, 1), ")"),
+				levels = "Mean (SD)"
+			)
+	} else if (cont == "median") {
+		df_out = x %>%
+			as.data.frame() %>%
+			dplyr::rename(Median = 6,
+						  Q3 = 8,
+						  Q1 = 4) %>%
+			dplyr::mutate(
+				Label = rownames(.),
+				IQR = Q3 - Q1,
+				Formatted = paste0(round(Median, 1), " (",
+								   round(IQR, 1), ")"),
+				levels = "Median (IQR)"
+			)
 	}
-
-	# Add back in actual labels
-	df.labels = data.frame(".id" = names(s$stats), "label" = s$labels)
-	df.out.labels = merge(df.out, df.labels, by = ".id")
-	if (orderbytotal==FALSE){
-		df.out.labels = df.out.labels[order(df.out.labels$index),] # reorder columns
-	} else {
-		df.out.labels = df.out.labels[order(-df.out.labels$index_total),] # reorder columns
-	}
-
-	# Reorder columns
-	label_index = which(names(df.out.labels) == "label")
-	not_label_index = which(names(df.out.labels) != "label")
-	df.out.labels = df.out.labels[,c(label_index,not_label_index)]
-
-	# Add glm levels name
-	if (fit_id){
-		levels = as.character(df.out.labels$levels)
-		levels[levels == "Mean (SD)"] = ""
-		levels[levels == "Median (IQR)"] = ""
-		df.out.labels$fit_id = paste0(df.out.labels$.id, levels)
-	}
-
-	# Remove
-	if (fit_id == FALSE) {
-		index_index = which(names(df.out.labels) == "index")
-	}else{
-		index_index = 0
-	}
-	id_index = which(names(df.out.labels) == ".id")
-	index_total_index = which(names(df.out.labels) == "index_total")
-	df.out.labels = df.out.labels[,-c(id_index, index_total_index, index_index)]
-
-	# Remove duplicate labels
-	df.out.labels = rm_duplicate_labels(df.out.labels, na_to_missing = na_to_missing)
-
-	# Add dependent name label
-	if(add_dependent_label){
-		df.out.labels = dependent_label(df.out=df.out.labels, .data=.data, dependent,
-																		prefix=dependent_label_prefix, suffix = dependent_label_suffix)
-	}
-
-	return(df.out.labels)
+	df_out %>%
+		dplyr::select(levels, Label, Formatted) %>%
+		tidyr::spread(Label, Formatted)
 }
 
 
-#' Summarise a set of factors by a dependent variable
+#' Helper function to generate the summary for a categorical variable
 #'
 #' Internal function, not called directly.
 #'
 #' @keywords internal
-
-summary_factorlist3 <- function(.data, dependent, explanatory, cont = "mean", cont_cut = 5, p = FALSE, na_include = FALSE,
-																column = FALSE, total_col = FALSE, orderbytotal = FALSE, fit_id = FALSE,
-																na_to_missing = TRUE, add_dependent_label = FALSE,
-																dependent_label_prefix = "Dependent: ", dependent_label_suffix = ""){
-	s <- summary_formula(as.formula(paste(dependent, "~", paste(explanatory, collapse = "+"))), data = .data,
-											 method = "reverse", overall = FALSE,
-											 test = TRUE,na.include = na_include, continuous = cont_cut)
-	# Column vs row proportions for factor variables
-	df.out = plyr::ldply(s$stats, function(x){
-		if(dim(x)[2] == 13){ #hack to get continuous vs categorical. Wouldn't work for factor with 13 levels
-			# Continuous variables
-			# Mean (SD)
-			if (cont == "mean"){
-				a = paste0(round(x[1,12], 1), " (", round(x[1,13], 1), ")")
-				b = paste0(round(x[2,12], 1), " (", round(x[2,13], 1), ")")
-				c = paste0(round(x[3,12], 1), " (", round(x[3,13], 1), ")")
-				row1_name = dimnames(x)[[2]][12]
-				row2_name = dimnames(x)[[2]][13]}
-
-			# Median (IQR)
-			if (cont == "median"){
-				a = paste0(x[1,6], " (", x[1,8]-x[1,4], ")")
-				b = paste0(x[2,6], " (", x[2,8]-x[2,4], ")")
-				c = paste0(x[3,6], " (", x[3,8]-x[3,4], ")")
-				row1_name = "Median"
-				row2_name = "IQR"}
-
-			col1_name = dimnames(x)[[1]][1]
-			col2_name = dimnames(x)[[1]][2]
-			col3_name = dimnames(x)[[1]][3]
-			df.out = data.frame(paste0(row1_name, " (", row2_name, ")"), a, b, c)
-			names(df.out) = c("levels", col1_name, col2_name, col3_name)
-		} else {
-			# Factor variables
-			row_name = dimnames(x)$w
-			col1_name = dimnames(x)$g[1]
-			col2_name = dimnames(x)$g[2]
-			col3_name = dimnames(x)$g[3]
-			col1 = x[,1]
-			col2 = x[,2]
-			col3 = x[,3]
-			total = col1 + col2 + col3
-			if (column == FALSE) {
-				col1_prop = (col1/apply(x, 1, sum))*100 # row margin
-				col2_prop = (col2/apply(x, 1, sum))*100
-				col3_prop = (col3/apply(x, 1, sum))*100
-			} else {
-				col1_prop = (col1/sum(col1))*100 # column margin
-				col2_prop = (col2/sum(col2))*100
-				col3_prop = (col3/sum(col3))*100
-				total_prop = (total/sum(total))*100
-			}
-			a = paste0(col1, " (", sprintf("%.1f", round(col1_prop, 1)), ")") #sprintf to keep trailing zeros
-			b = paste0(col2, " (", sprintf("%.1f", round(col2_prop, 1)), ")")
-			c = paste0(col3, " (", sprintf("%.1f", round(col3_prop, 1)), ")")
-			if (total_col == FALSE){
-				df.out = data.frame(row_name, a, b, c)
-				names(df.out) = c("levels", col1_name, col2_name, col3_name)
-			} else if (total_col == TRUE & column == FALSE) {
-				df.out = data.frame(row_name, a, b, c, total, total)
-				names(df.out) = c("levels", col1_name, col2_name, col3_name, "Total", "index_total")
-			} else if (total_col == TRUE & column == TRUE) {
-				df.out = data.frame(row_name, a, b, c, paste0(total, " (", sprintf("%.1f", round(total_prop, 1)), ")"), total)
-				names(df.out) = c("levels", col1_name, col2_name, col3_name, "Total", "index_total")
-			}
-		}
-		return(df.out)
-	})
-	# Keep original order
-	df.out$index = 1:dim(df.out)[1]
-
-	if (p == TRUE){
-		a = plyr::ldply(s$testresults, function(x) sprintf("%.3f",round(x[[1]], 3)))
-		names(a) = c(".id", "p")
-		df.out = merge(df.out, a, by=".id")
+summarize_categorical = function(x, column, total_col) {
+	format_n_percent = function(n, percent) {
+		# sprintf to keep trailing zeros
+		percent = sprintf("%.1f", round(percent, 1))
+		paste0(n, " (", percent, ")")
 	}
 
-	# Add back in actual labels
-	df.labels = data.frame(".id" = names(s$stats), "label" = s$labels)
-	df.out.labels = merge(df.out, df.labels, by = ".id")
-	if (orderbytotal==FALSE){
-		df.out.labels = df.out.labels[order(df.out.labels$index),] # reorder columns
+	# Workaround for CRAN checks: need to declare any variables that
+	#   will be used in dplyr non-standard evaluation
+	w = NULL; Freq = NULL; g = NULL; total_prop = NULL; Prop = NULL;
+	Formatted = NULL; index_total = NULL;
+
+	# Calculate totals
+	df = x %>%
+		as.data.frame() %>%
+		dplyr::group_by(w) %>%
+		dplyr::mutate(Total = sum(Freq),
+					  index_total = Total) %>%
+		dplyr::group_by(g) %>%
+		dplyr::mutate(total_prop = Total / sum(Total) * 100)
+
+
+	# Calculate percentage: row-wise or column-wise
+	if (column) {
+		df = df %>%
+			dplyr::group_by(g) %>%
+			dplyr::mutate(Prop = Freq / sum(Freq) * 100,
+						  Total = format_n_percent(Total, total_prop))
 	} else {
-		df.out.labels = df.out.labels[order(-df.out.labels$index_total),] # reorder columns
+		df = df %>%
+			dplyr::group_by(w) %>%
+			dplyr::mutate(Prop = Freq / sum(Freq) * 100)
 	}
 
-	# Reorder columns and remove unnecessary columns
-	# Reorder
-	label_index = which(names(df.out.labels) == "label")
-	not_label_index = which(names(df.out.labels) != "label")
-	df.out.labels = df.out.labels[,c(label_index,not_label_index)]
+	# Finalize and reshape
+	df = df %>%
+		dplyr::ungroup() %>%
+		dplyr::mutate(Formatted = format_n_percent(Freq, Prop)) %>%
+		dplyr::select(levels = w, g, Formatted, Total, index_total) %>%
+		tidyr::spread(g, Formatted)
 
-	# Remove
-	id_index = which(names(df.out.labels) == ".id")
-	index_index = which(names(df.out.labels) == "index")
-	index_total_index = which(names(df.out.labels) == "index_total")
-	df.out.labels = df.out.labels[,-c(id_index, index_index, index_total_index)]
-
-	# Remove duplicate labels
-	df.out.labels = rm_duplicate_labels(df.out.labels, na_to_missing = na_to_missing)
-
-	# Add dependent name label
-	if(add_dependent_label){
-		df.out.labels = dependent_label(df.out=df.out.labels, .data=.data, dependent,
-																		prefix=dependent_label_prefix, suffix = dependent_label_suffix)
-	}
-
-
-	return(df.out.labels)
-}
-
-
-
-#' Summarise a set of factors by a dependent variable
-#'
-#' Internal function, not called directly.
-#'
-#' @keywords internal
-
-summary_factorlist4 <- function(.data, dependent, explanatory,  cont = "mean", cont_cut = 5, p = FALSE, na_include = FALSE,
-																column = FALSE, total_col = FALSE, orderbytotal = FALSE, fit_id = FALSE,
-																na_to_missing = TRUE, add_dependent_label = FALSE,
-																dependent_label_prefix = "Dependent: ", dependent_label_suffix = ""){
-	s <- summary_formula(as.formula(paste(dependent, "~", paste(explanatory, collapse = "+"))), data = .data,
-											 method = "reverse", overall = FALSE,
-											 test = TRUE,na.include = na_include, continuous = cont_cut)
-	# Column vs row proportions for factor variables
-	df.out = plyr::ldply(s$stats, function(x){
-		if(dim(x)[2] == 13){ #hack to get continuous vs categorical. Wouldn't work for factor with 13 levels
-			# Continuous variables
-			# Mean (SD)
-			if (cont == "mean"){
-				a = paste0(round(x[1,12], 1), " (", round(x[1,13], 1), ")")
-				b = paste0(round(x[2,12], 1), " (", round(x[2,13], 1), ")")
-				c = paste0(round(x[3,12], 1), " (", round(x[3,13], 1), ")")
-				d = paste0(round(x[4,12], 1), " (", round(x[4,13], 1), ")")
-				row1_name = dimnames(x)[[2]][12]
-				row2_name = dimnames(x)[[2]][13]
-			}
-
-			# Median (IQR)
-			if (cont == "median"){
-				a = paste0(x[1,6], " (", x[1,8]-x[1,4], ")")
-				b = paste0(x[2,6], " (", x[2,8]-x[2,4], ")")
-				c = paste0(x[3,6], " (", x[3,8]-x[3,4], ")")
-				d = paste0(x[4,6], " (", x[4,8]-x[4,4], ")")
-				row1_name = "Median"
-				row2_name = "IQR"}
-
-			col1_name = dimnames(x)[[1]][1]
-			col2_name = dimnames(x)[[1]][2]
-			col3_name = dimnames(x)[[1]][3]
-			col4_name = dimnames(x)[[1]][4]
-			df.out = data.frame(paste0(row1_name, " (", row2_name, ")"), a, b, c, d)
-			names(df.out) = c("levels", col1_name, col2_name, col3_name,col4_name)
-		} else {
-			# Factor variables
-			row_name = dimnames(x)$w
-			col1_name = dimnames(x)$g[1]
-			col2_name = dimnames(x)$g[2]
-			col3_name = dimnames(x)$g[3]
-			col4_name = dimnames(x)$g[4]
-			col1 = x[,1]
-			col2 = x[,2]
-			col3 = x[,3]
-			col4 = x[,4]
-			total = col1 + col2 + col3 + col4
-			if (column == FALSE) {
-				col1_prop = (col1/apply(x, 1, sum))*100 # row margin
-				col2_prop = (col2/apply(x, 1, sum))*100
-				col3_prop = (col3/apply(x, 1, sum))*100
-				col4_prop = (col4/apply(x, 1, sum))*100
-			} else {
-				col1_prop = (col1/sum(col1))*100 # column margin
-				col2_prop = (col2/sum(col2))*100
-				col3_prop = (col3/sum(col3))*100
-				col4_prop = (col4/sum(col4))*100
-				total_prop = (total/sum(total))*100
-			}
-			a = paste0(col1, " (", sprintf("%.1f", round(col1_prop, 1)), ")") #sprintf to keep trailing zeros
-			b = paste0(col2, " (", sprintf("%.1f", round(col2_prop, 1)), ")")
-			c = paste0(col3, " (", sprintf("%.1f", round(col3_prop, 1)), ")")
-			d = paste0(col4, " (", sprintf("%.1f", round(col4_prop, 1)), ")")
-			if (total_col == FALSE){
-				df.out = data.frame(row_name, a, b, c, d)
-				names(df.out) = c("levels", col1_name, col2_name, col3_name, col4_name)
-			} else if (total_col == TRUE & column == FALSE) {
-				df.out = data.frame(row_name, a, b, c, d, total, total)
-				names(df.out) = c("levels", col1_name, col2_name, col3_name, col4_name, "Total", "index_total")
-			} else if (total_col == TRUE & column == TRUE) {
-				df.out = data.frame(row_name, a, b, c, d, paste0(total, " (", sprintf("%.1f", round(total_prop, 1)), ")"), total)
-				names(df.out) = c("levels", col1_name, col2_name, col3_name, col4_name, "Total", "index_total")
-			}
-		}
-		return(df.out)
-	})
-	# Keep original order
-	df.out$index = 1:dim(df.out)[1]
-
-	if (p == TRUE){
-		a = plyr::ldply(s$testresults, function(x) sprintf("%.3f",round(x[[1]], 3)))
-		names(a) = c(".id", "p")
-		df.out = merge(df.out, a, by=".id")
-	}
-
-	# Add back in actual labels
-	df.labels = data.frame(".id" = names(s$stats), "label" = s$labels)
-	df.out.labels = merge(df.out, df.labels, by = ".id")
-	if (orderbytotal==FALSE){
-		df.out.labels = df.out.labels[order(df.out.labels$index),] # reorder columns
+	# Drop totals if not required
+	if (total_col) {
+		df = df %>%
+			# dplyr trick to move column to the end
+			dplyr::select(-Total, -index_total, Total, index_total)
 	} else {
-		df.out.labels = df.out.labels[order(-df.out.labels$index_total),] # reorder columns
+		df = df %>%
+			dplyr::select(-Total, -index_total)
 	}
 
-	# Reorder columns and remove unnecessary columns
-	# Reorder
-	label_index = which(names(df.out.labels) == "label")
-	not_label_index = which(names(df.out.labels) != "label")
-	df.out.labels = df.out.labels[,c(label_index,not_label_index)]
-
-	# Remove
-	id_index = which(names(df.out.labels) == ".id")
-	index_index = which(names(df.out.labels) == "index")
-	index_total_index = which(names(df.out.labels) == "index_total")
-	df.out.labels = df.out.labels[,-c(id_index, index_index, index_total_index)]
-
-	# Remove duplicate labels
-	df.out.labels = rm_duplicate_labels(df.out.labels, na_to_missing = na_to_missing)
-
-	# Add dependent name label
-	if(add_dependent_label){
-		df.out.labels = dependent_label(df.out=df.out.labels, .data=.data, dependent,
-																		prefix=dependent_label_prefix, suffix = dependent_label_suffix)
-	}
-
-
-	return(df.out.labels)
-}
-
-
-#' Summarise a set of factors by a dependent variable
-#'
-#' Internal function, not called directly.
-#'
-#' @keywords internal
-
-summary_factorlist5 <- function(.data, dependent, explanatory, cont = "mean", cont_cut = 5, p = FALSE, na_include = FALSE,
-																column = FALSE, total_col = FALSE, orderbytotal = FALSE, fit_id = FALSE,
-																na_to_missing = TRUE, add_dependent_label = FALSE,
-																dependent_label_prefix = "Dependent: ", dependent_label_suffix = ""){
-	s <- summary_formula(as.formula(paste(dependent, "~", paste(explanatory, collapse = "+"))), data = .data,
-											 method = "reverse", overall = FALSE,
-											 test = TRUE,na.include = na_include, continuous = cont_cut)
-	# Column vs row proportions for factor variables
-	df.out = plyr::ldply(s$stats, function(x){
-		if(dim(x)[2] == 13){ #hack to get continuous vs categorical. Wouldn't work for factor with 13 levels
-			# Continuous variables
-			# Mean (SD)
-			if (cont == "mean"){
-				a = paste0(round(x[1,12], 1), " (", round(x[1,13], 1), ")")
-				b = paste0(round(x[2,12], 1), " (", round(x[2,13], 1), ")")
-				c = paste0(round(x[3,12], 1), " (", round(x[3,13], 1), ")")
-				d = paste0(round(x[4,12], 1), " (", round(x[4,13], 1), ")")
-				e = paste0(round(x[5,12], 1), " (", round(x[5,13], 1), ")")
-				row1_name = dimnames(x)[[2]][12]
-				row2_name = dimnames(x)[[2]][13]
-			}
-
-			# Median (IQR)
-			if (cont == "median"){
-				a = paste0(x[1,6], " (", x[1,8]-x[1,4], ")")
-				b = paste0(x[2,6], " (", x[2,8]-x[2,4], ")")
-				c = paste0(x[3,6], " (", x[3,8]-x[3,4], ")")
-				d = paste0(x[4,6], " (", x[4,8]-x[4,4], ")")
-				e = paste0(x[5,6], " (", x[5,8]-x[5,4], ")")
-				row1_name = "Median"
-				row2_name = "IQR"}
-
-			col1_name = dimnames(x)[[1]][1]
-			col2_name = dimnames(x)[[1]][2]
-			col3_name = dimnames(x)[[1]][3]
-			col4_name = dimnames(x)[[1]][4]
-			col5_name = dimnames(x)[[1]][5]
-			df.out = data.frame(paste0(row1_name, " (", row2_name, ")"), a, b, c, d, e)
-			names(df.out) = c("levels", col1_name, col2_name, col3_name,col4_name, col5_name)
-		} else {
-			# Factor variables
-			row_name = dimnames(x)$w
-			col1_name = dimnames(x)$g[1]
-			col2_name = dimnames(x)$g[2]
-			col3_name = dimnames(x)$g[3]
-			col4_name = dimnames(x)$g[4]
-			col5_name = dimnames(x)$g[5]
-			col1 = x[,1]
-			col2 = x[,2]
-			col3 = x[,3]
-			col4 = x[,4]
-			col5 = x[,5]
-			total = col1 + col2 + col3 + col4 + col5
-			if (column == FALSE) {
-				col1_prop = (col1/apply(x, 1, sum))*100 # row margin
-				col2_prop = (col2/apply(x, 1, sum))*100
-				col3_prop = (col3/apply(x, 1, sum))*100
-				col4_prop = (col4/apply(x, 1, sum))*100
-				col5_prop = (col5/apply(x, 1, sum))*100
-			} else {
-				col1_prop = (col1/sum(col1))*100 # column margin
-				col2_prop = (col2/sum(col2))*100
-				col3_prop = (col3/sum(col3))*100
-				col4_prop = (col4/sum(col4))*100
-				col5_prop = (col5/sum(col5))*100
-				total_prop = (total/sum(total))*100
-			}
-			a = paste0(col1, " (", sprintf("%.1f", round(col1_prop, 1)), ")") #sprintf to keep trailing zeros
-			b = paste0(col2, " (", sprintf("%.1f", round(col2_prop, 1)), ")")
-			c = paste0(col3, " (", sprintf("%.1f", round(col3_prop, 1)), ")")
-			d = paste0(col4, " (", sprintf("%.1f", round(col4_prop, 1)), ")")
-			e = paste0(col5, " (", sprintf("%.1f", round(col5_prop, 1)), ")")
-			if (total_col == FALSE){
-				df.out = data.frame(row_name, a, b, c, d, e)
-				names(df.out) = c("levels", col1_name, col2_name, col3_name, col4_name, col5_name)
-			} else if (total_col == TRUE & column == FALSE) {
-				df.out = data.frame(row_name, a, b, c, d, e, total, total)
-				names(df.out) = c("levels", col1_name, col2_name, col3_name, col4_name, col5_name, "Total", "index_total")
-			} else if (total_col == TRUE & column == TRUE) {
-				df.out = data.frame(row_name, a, b, c, d, e, paste0(total, " (", sprintf("%.1f", round(total_prop, 1)), ")"), total)
-				names(df.out) = c("levels", col1_name, col2_name, col3_name, col4_name, col5_name, "Total", "index_total")
-			}
-		}
-		return(df.out)
-	})
-	# Keep original order
-	df.out$index = 1:dim(df.out)[1]
-
-	if (p == TRUE){
-		a = plyr::ldply(s$testresults, function(x) sprintf("%.3f",round(x[[1]], 3)))
-		names(a) = c(".id", "p")
-		df.out = merge(df.out, a, by=".id")
-	}
-
-	# Add back in actual labels
-	df.labels = data.frame(".id" = names(s$stats), "label" = s$labels)
-	df.out.labels = merge(df.out, df.labels, by = ".id")
-	if (orderbytotal==FALSE){
-		df.out.labels = df.out.labels[order(df.out.labels$index),] # reorder columns
-	} else {
-		df.out.labels = df.out.labels[order(-df.out.labels$index_total),] # reorder columns
-	}
-
-	# Reorder columns and remove unnecessary columns
-	# Reorder
-	label_index = which(names(df.out.labels) == "label")
-	not_label_index = which(names(df.out.labels) != "label")
-	df.out.labels = df.out.labels[,c(label_index,not_label_index)]
-
-	# Remove
-	id_index = which(names(df.out.labels) == ".id")
-	index_index = which(names(df.out.labels) == "index")
-	index_total_index = which(names(df.out.labels) == "index_total")
-	df.out.labels = df.out.labels[,-c(id_index, index_index, index_total_index)]
-
-	# Remove duplicate labels
-	df.out.labels = rm_duplicate_labels(df.out.labels, na_to_missing = na_to_missing)
-
-	# Add dependent name label
-	if(add_dependent_label){
-		df.out.labels = dependent_label(df.out=df.out.labels, .data=.data, dependent,
-																		prefix=dependent_label_prefix, suffix = dependent_label_suffix)
-	}
-
-
-	return(df.out.labels)
+	return(df)
 }


### PR DESCRIPTION
I was looking at the source for `summary_factorlist` this week to see how easy it would be to add a feature to it, and noticed there was a bit of code duplication with `summary_factorlist1`, `summary_factorlist2`, etc. This PR is an attempt to rewrite some of that implementation with code that is (hopefully) cleaner and more maintainable. Obviously it uses `dplyr`/`tidyr` heavily but they were already imports for this package so hopefully that's OK.

The PR may not be ready to merge just yet, I just wanted to see if you would be open to this kind of change. Happy to address any issues you may have.

I've checked to make sure all tests and CRAN checks pass with the reworked code, and have done some additional testing to make sure the output is the same before and after.