### PR TITLE
Docs: include_row_missing_col requires add_row_totals = TRUE

### DIFF
--- a/R/summaryfactorlist.R
+++ b/R/summaryfactorlist.R
@@ -63,7 +63,7 @@
 #' @param add_row_totals Logical. Include row totals. Note this differs from
 #'   \code{total_col} above particularly for continuous explanatory variables.
 #' @param include_row_missing_col Logical. Include missing data total for each
-#'   row.
+#'   row. Only used when \code(add_row_totals} is \code{TRUE}.
 #' @param row_totals_colname Character. Column name for row totals.
 #' @param row_missing_colname Character. Column name for missing data totals for
 #'   each row.


### PR DESCRIPTION
Just a small fix: I was just trying to use `include_row_missing_col` in `summary_factorlist()` and it had no effect. It was only by looking at the source that I could see it only worked with `add_row_totals = TRUE`, so I've added that to the function documentation.