### PR TITLE
Changes for dplyr 1.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,10 +34,11 @@ Imports:
     stats,
     stringr,
     survival,
-    tidyr (>= 1.0.0)
+    tidyr (>= 1.0.0),
+    tibble
 RoxygenNote: 6.1.1
 Suggests:
-    cmprsk, 
+    cmprsk,
     knitr,
     readr,
     rlang,
@@ -45,6 +46,5 @@ Suggests:
     rstan,
     survey,
     survminer,
-    testthat,
-    tibble
+    testthat
 VignetteBuilder: knitr

--- a/R/ff_glimpse.R
+++ b/R/ff_glimpse.R
@@ -96,7 +96,7 @@ ff_glimpse <- function(.data, dependent=NULL, explanatory=NULL, digits = 1,
 																	format(digits = 2) %>%
 																	paste(collapse=", "),
 																"-")
-				df.out = dplyr::data_frame(levels_n, levels, levels_count, levels_percent) %>% data.frame()
+				df.out = tibble::tibble(levels_n, levels, levels_count, levels_percent) %>% data.frame()
 			}) -> df.factors.out2
 
 		df.factors.out = data.frame(df.factors.out1, df.factors.out2)

--- a/R/ff_label.R
+++ b/R/ff_label.R
@@ -84,13 +84,13 @@ extract_variable_label = function(.data){
 ff_relabel <- function(.data, .labels){
 	# Keep only labels for variables in data
 	.labels = .labels[names(.labels) %in% names(.data)]
+	relabel_one <- function(.){
+	  var <- as.character(match.call()[[2L]])
+	  label = .labels[[var]]
+	  ff_label(., label)
+	}
 	.data %>% 
-		dplyr::mutate_at(names(.labels), # Apply only to variables for which labels
-										 dplyr::funs({
-										 	label = .labels[[dplyr::quo_name(dplyr::quo(.))]]
-										 	ff_label(., label)
-										 })
-		)
+		dplyr::mutate_at(names(.labels), relabel_one) # Apply only to variables for which labels
 }
 
 #' @rdname ff_relabel
@@ -112,13 +112,13 @@ finalfit_relabel <- ff_relabel
 ff_relabel_df <- function(.data, .df){
 	.labels = extract_variable_label(.df)
 	.labels = .labels[names(.labels) %in% names(.data)]
+	relabel_one <- function(.) {
+	  var <- as.character(match.call()[[2L]])
+	  label = .labels[[var]]
+	  ff_label(., label)
+	}
 	.data %>% 
-		dplyr::mutate_at(names(.labels), # Apply only to variables for which labels
-										 dplyr::funs({
-										 	label = .labels[[dplyr::quo_name(dplyr::quo(.))]]
-										 	ff_label(., label)
-										 })
-		)
+		dplyr::mutate_at(names(.labels), relabel_one) # Apply only to variables for which labels
 }
 #' @rdname ff_relabel_df
 #' @export

--- a/R/missing_glimpse.R
+++ b/R/missing_glimpse.R
@@ -30,7 +30,7 @@ missing_glimpse <- function(.data, dependent=NULL, explanatory=NULL, digits = 1)
 			missing_n = sum(is.na(x))
 			n = obs-missing_n
 			missing_percent = round_tidy(100*missing_n/obs, digits=digits)
-			dplyr::data_frame(var_type, n, missing_n, missing_percent)
+			tibble::tibble(var_type, n, missing_n, missing_percent)
 		}) -> df.out1
 
 	df.in %>%


### PR DESCRIPTION
Minor changes to accommodate for dplyr 1.0.0 imminent release. These were just minor deprecation issues. 

Once `dplyr` is out, we'll have a better way of rewriting the `funs()` code, but for now this should work with both cran version and next version, so feel free to release `finalfit`. 

